### PR TITLE
Add `MapPolyline` and `stroke`

### DIFF
--- a/Sources/LiveViewNativeMapKit/MapContent/MapPolyline.swift
+++ b/Sources/LiveViewNativeMapKit/MapContent/MapPolyline.swift
@@ -1,0 +1,69 @@
+//
+//  MapPolyline.swift
+//
+//
+//  Created by Carson Katri on 7/25/23.
+//
+
+import LiveViewNative
+import MapKit
+import SwiftUI
+import CoreLocation
+
+/// Create a line between a set of coordinates.
+///
+/// Use `<Coordinate>` elements within the `<MapPolyline>` to create a line.
+///
+/// ```html
+/// <MapPolyline contour-style="geodesic">
+///   <Coordinate latitude={38.8951} longitude={-77.0364} />
+///   <Coordinate latitude={39.8951} longitude={-76.0364} />
+///   <Coordinate latitude={40.8951} longitude={-78.0364} />
+/// </MapPolyline>
+/// ```
+@_documentation(visibility: public)
+struct MapPolyline<R: RootRegistry>: MapContent {
+    /// The points of the polyline path.
+    @_documentation(visibility: public)
+    let coordinates: [CLLocationCoordinate2D]
+    
+    /// The way lines are drawn. Defaults to `straight`.
+    ///
+    /// Possible values:
+    /// * ``geodesic``
+    /// * ``straight``
+    @_documentation(visibility: public)
+    let contourStyle: MapKit.MapPolyline.ContourStyle
+    
+    let element: ElementNode
+    let context: MapContentBuilder.Context<R>
+    
+    init(element: ElementNode, context: MapContentBuilder.Context<R>) throws {
+        self.coordinates = try element
+            .elementChildren()
+            .filter { $0.tag == "Coordinate" }
+            .map {
+                .init(
+                    latitude: try $0.attributeValue(Double.self, for: "latitude"),
+                    longitude: try $0.attributeValue(Double.self, for: "longitude")
+                )
+            }
+        
+        switch try element.attributeValue(String.self, for: "contour-style") {
+        case "geodesic":
+            self.contourStyle = .geodesic
+        case "straight":
+            self.contourStyle = .straight
+        default:
+            self.contourStyle = .straight
+        }
+        
+        self.element = element
+        self.context = context
+    }
+    
+    @MapKit.MapContentBuilder
+    var body: some MapContent {
+        MapKit.MapPolyline(coordinates: coordinates, contourStyle: contourStyle)
+    }
+}

--- a/Sources/LiveViewNativeMapKit/MapContentBuilder.swift
+++ b/Sources/LiveViewNativeMapKit/MapContentBuilder.swift
@@ -11,18 +11,22 @@ import LiveViewNative
 
 enum MapContentBuilder: ContentBuilder {
     enum TagName: String {
+        case mapPolyline = "MapPolyline"
         case marker = "Marker"
     }
     
     enum ModifierType: String, Decodable {
         case foregroundStyle = "foreground_style"
+        case stroke
         case tint
     }
     
     typealias Content = any MapContent
     
     static func lookup<R: RootRegistry>(_ tag: TagName, element: ElementNode, context: Context<R>) -> Content {
-        let content = switch tag {
+        let content: any MapContent = switch tag {
+        case .mapPolyline:
+            try! MapPolyline<R>(element: element, context: context)
         case .marker:
             try! Marker<R>(element: element, context: context)
         }
@@ -40,6 +44,8 @@ enum MapContentBuilder: ContentBuilder {
         switch type {
         case .foregroundStyle:
             return try ForegroundStyleModifier(from: decoder)
+        case .stroke:
+            return try StrokeModifier(from: decoder)
         case .tint:
             return try TintModifier(from: decoder)
         }

--- a/Sources/LiveViewNativeMapKit/Modifiers/StrokeModifier.swift
+++ b/Sources/LiveViewNativeMapKit/Modifiers/StrokeModifier.swift
@@ -1,0 +1,25 @@
+//
+//  StrokeModifier.swift
+//
+//
+//  Created by Carson Katri on 7/25/23.
+//
+
+import SwiftUI
+import MapKit
+import LiveViewNative
+
+struct StrokeModifier: ContentModifier {
+    typealias Builder = MapContentBuilder
+    
+    let color: Color
+    let style: StrokeStyle?
+    
+    func apply<R: RootRegistry>(
+        to content: Builder.Content,
+        on element: ElementNode,
+        in context: Builder.Context<R>
+    ) -> Builder.Content {
+        return content.stroke(self.color, style: style ?? .init())
+    }
+}

--- a/lib/live_view_native_swift_ui_map_kit/modifiers/stroke.ex
+++ b/lib/live_view_native_swift_ui_map_kit/modifiers/stroke.ex
@@ -1,0 +1,29 @@
+defmodule LiveViewNativeSwiftUiMapKit.Modifiers.Stroke do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.{ShapeStyle, Color, StrokeStyle}
+
+  modifier_schema "stroke" do
+    field :content, ShapeStyle
+    field :color, Color
+    field :style, StrokeStyle
+  end
+
+  def params(content, [style: style]) do
+    with {:ok, _} <- ShapeStyle.cast(content) do
+      [content: content, style: style]
+    else
+      _ ->
+        [color: content, style: style]
+    end
+  end
+  def params(params) when is_list(params), do: params
+  def params(content) do
+    with {:ok, _} <- ShapeStyle.cast(content) do
+      [content: content]
+    else
+      _ ->
+        [color: content]
+    end
+  end
+end


### PR DESCRIPTION
Closes #7 

> **Note**
> The stroke modifier can only be used with `Color` content at this time:
```html
<MapPolyline modifiers={stroke(:red, style: [line_width: 5])}>
  ...
</MapPolyline>
```

![Simulator Screenshot - iPhone 14 Pro - 2023-07-25 at 11 18 25](https://github.com/liveview-native/liveview-native-swiftui-mapkit/assets/13581484/5fe38c89-2810-4d03-a4bf-59bd53c9dd9f)
