### PR TITLE
Use `@Addon` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Usage
 
-When using Swift 5.9+, add the `MapKitRegistry` to the `addons` list of your `#LiveView`.
+Add `.mapKit` to the `addons` list of your `#LiveView`.
 
 ```swift
 import SwiftUI
@@ -24,33 +24,8 @@ struct ContentView: View {
     var body: some View {
         #LiveView(
           .localhost,
-          addons: [MapKitRegistry<_>.self] // 2. Include the `MapKitRegistry`.
+          addons: [.mapKit] // 2. Include the `MapKit` addon.
         )
-    }
-}
-```
-
-If you are on an older version of Swift, add the `MapKitRegistry` to your app's `AggregateRegistry`.
-
-```diff
-import SwiftUI
-import LiveViewNative
-+ import LiveViewNativeMapKit
-+ 
-+ struct MyRegistry: CustomRegistry {
-+     typealias Root = AppRegistries
-+ }
-+ 
-+ struct AppRegistries: AggregateRegistry {
-+     #Registries<
-+         MyRegistry,
-+         MapKitRegistry<Self>
-+     >
-+ }
-
-struct ContentView: View {
-    var body: some View {
-        LiveView<AppRegistries>(.localhost)
     }
 }
 ```

--- a/Sources/LiveViewNativeMapKit/LiveViewNativeMapKit.docc/LiveViewNativeMapKit.md
+++ b/Sources/LiveViewNativeMapKit/LiveViewNativeMapKit.docc/LiveViewNativeMapKit.md
@@ -1,6 +1,6 @@
 # ``LiveViewNativeMapKit``
 
-`liveview-native-swiftui-mapkit` is an add-on library for LiveView Native. It adds MapKit support for displaying interactive maps.
+`liveview-native-swiftui-mapkit` is an add-on library for [LiveView Native](https://github.com/liveview-native/live_view_native). It adds [MapKit](https://developer.apple.com/documentation/mapkit) support for displaying interactive maps.
 
 ## Installation
 
@@ -11,7 +11,7 @@
 
 ## Usage
 
-When using Swift 5.9+, add the `MapKitRegistry` to the `addons` list of your `#LiveView`.
+Add `.mapKit` to the `addons` list of your `#LiveView`.
 
 ```swift
 import SwiftUI
@@ -22,33 +22,8 @@ struct ContentView: View {
     var body: some View {
         #LiveView(
           .localhost,
-          addons: [MapKitRegistry<_>.self] // 2. Include the `MapKitRegistry`.
+          addons: [.mapKit] // 2. Include the `MapKit` addon.
         )
-    }
-}
-```
-
-If you are on an older version of Swift, add the `MapKitRegistry` to your app's `AggregateRegistry`.
-
-```diff
-import SwiftUI
-import LiveViewNative
-+ import LiveViewNativeMapKit
-+ 
-+ struct MyRegistry: CustomRegistry {
-+     typealias Root = AppRegistries
-+ }
-+ 
-+ struct AppRegistries: AggregateRegistry {
-+     #Registries<
-+         MyRegistry,
-+         MapKitRegistry<Self>
-+     >
-+ }
-
-struct ContentView: View {
-    var body: some View {
-        LiveView<AppRegistries>(.localhost)
     }
 }
 ```

--- a/Sources/LiveViewNativeMapKit/MapKitRegistry.swift
+++ b/Sources/LiveViewNativeMapKit/MapKitRegistry.swift
@@ -2,40 +2,43 @@ import LiveViewNative
 import LiveViewNativeStylesheet
 import SwiftUI
 
-/// A registry that includes the ``Map`` element and associated modifiers.
-public enum MapKitRegistry<Root: RootRegistry>: CustomRegistry {
-    public enum TagName: String {
-        case map = "Map"
-    }
-    
-    public static func lookup(_ name: TagName, element: ElementNode) -> some View {
-        switch name {
-        case .map:
-            Map<Root>()
-        }
-    }
-    
-    public struct CustomModifier: ViewModifier, ParseableModifierValue {
-        enum Storage {
-            case lookAroundViewer(LookAroundViewerModifier)
-            case noop
+public extension Addons {
+    /// A registry that includes the ``Map`` element and associated modifiers.
+    @Addon
+    public struct MapKit<Root: RootRegistry> {
+        public enum TagName: String {
+            case map = "Map"
         }
         
-        let storage: Storage
-        
-        public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-            CustomModifierGroupParser(output: Self.self) {
-                LookAroundViewerModifier.parser(in: context).map({ Self(storage: .lookAroundViewer($0)) })
-                MapContentBuilder.ModifierType.parser(in: context).map({ _ in Self(storage: .noop) })
+        public static func lookup(_ name: TagName, element: ElementNode) -> some View {
+            switch name {
+            case .map:
+                Map<Root>()
             }
         }
         
-        public func body(content: Content) -> some View {
-            switch storage {
-            case .lookAroundViewer(let lookAroundViewerModifier):
-                content.modifier(lookAroundViewerModifier)
-            case .noop:
-                content
+        public struct CustomModifier: ViewModifier, ParseableModifierValue {
+            enum Storage {
+                case lookAroundViewer(LookAroundViewerModifier)
+                case noop
+            }
+            
+            let storage: Storage
+            
+            public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+                CustomModifierGroupParser(output: Self.self) {
+                    LookAroundViewerModifier.parser(in: context).map({ Self(storage: .lookAroundViewer($0)) })
+                    MapContentBuilder.ModifierType.parser(in: context).map({ _ in Self(storage: .noop) })
+                }
+            }
+            
+            public func body(content: Content) -> some View {
+                switch storage {
+                case .lookAroundViewer(let lookAroundViewerModifier):
+                    content.modifier(lookAroundViewerModifier)
+                case .noop:
+                    content
+                }
             }
         }
     }


### PR DESCRIPTION
Currently, the `@Addon` macro is only available on the `main` branch of `liveview-client-swiftui`. This should depend on a specific release instead before merging.